### PR TITLE
Create folder if it does not exist

### DIFF
--- a/app/services/google_drive_service.rb
+++ b/app/services/google_drive_service.rb
@@ -1,3 +1,5 @@
+require "fileutils"
+
 # GoogleDriveService contains methods to upload files to Google Drive.
 #
 # It will be ready to be used only if all the environment variables are set.
@@ -46,7 +48,12 @@ class GoogleDriveService < CloudService
       universe_domain: "googleapis.com"
     }
 
-    File.open("config/credentials/#{project.key.downcase}_google_service_account.json", "w") do |file|
+    path = "config/credentials"
+
+    # Create the directory if it doesn't exist
+    FileUtils.mkdir_p(File.dirname(path))
+
+    File.open("#{path}/#{project.key.downcase}_google_service_account.json", "w") do |file|
       file.write(JSON.pretty_generate(credentials))
     end
   end
@@ -142,6 +149,10 @@ class GoogleDriveService < CloudService
 
     file_name = extract_file_name_from_url(url, save_path)
     full_path = File.join(save_path, file_name)
+
+    # Create the directory if it doesn't exist
+    FileUtils.mkdir_p(File.dirname(save_path))
+
     File.open(full_path, "wb") { |file| file.write(response.body) }
 
     full_path


### PR DESCRIPTION
<img width="868" alt="Captura de Tela 2023-10-23 às 19 32 02" src="https://github.com/arturcp/cloud-orchestrator/assets/523071/4a869a12-bfdb-4770-8edd-66bc3775aded">

I am getting an error when trying to configure the service because the folder where the credentials will be placed does not exist. Thus, I am opening this PR to automatically create the folder in the first run.