### PR TITLE
Manually build google drive credentials file

### DIFF
--- a/app/services/google_drive_service.rb
+++ b/app/services/google_drive_service.rb
@@ -50,16 +50,15 @@ class GoogleDriveService < CloudService
 
     credentials_path = Rails.root.join("config/credentials")
 
-    # Create the directory if it doesn't exist
     unless File.directory?(credentials_path)
       FileUtils.mkdir_p(credentials_path)
     end
 
     credentials_file_path = "#{credentials_path}/#{project.key.downcase}_google_service_account.json"
-
-    # Remove double slashes that are being generated when a \n is present in the keys
-    credentials_json = JSON.pretty_generate(credentials)
-    credentials_json.gsub!("\\n", "\n")
+    credentials_json = credentials.map do |key, value|
+      "  \"#{key}\": \"#{value.gsub("\n", "\\n")}\""
+    end.join(",\n")
+    credentials_json = "{\n#{credentials_json}\n}"
 
     File.open(credentials_file_path, "w") do |file|
       file.write(credentials_json)

--- a/lib/tasks/configure_services.rake
+++ b/lib/tasks/configure_services.rake
@@ -11,8 +11,6 @@ namespace :cloud_orchestrator do
       Projects.list.each do |project|
         log "  * #{project.name}"
         result = service.configure(project)
-
-        log "(#{result})" if result
       end
 
       log ""


### PR DESCRIPTION
We are having issues with double slashes and line breaks when creating the credentials file. Instead of relying on package solutions, we are going to build it with our own code to have full control of the output.